### PR TITLE
RSDK-1610 Use global lock ordering in Atlas.cc

### DIFF
--- a/src/System.cc
+++ b/src/System.cc
@@ -1421,10 +1421,13 @@ void System::SaveAtlas(int type){
     if(!mStrSaveAtlasToFile.empty())
     {
         //clock_t start = clock();
-
-        // Save the current session
-        mpAtlas->PreSave();
-        
+        {
+            // PreSave assumes that the current map is locked
+            Map* currentMap = mpAtlas.GetCurrentMap();
+            std::lock_guard<std::mutex> lock(currentMap -> mMutexMapUpdate ); 
+            // Save the current session
+            mpAtlas->PreSave();
+        }
         string pathSaveFileName = mStrSaveAtlasToFile;
         // pathSaveFileName = pathSaveFileName.append(mStrSaveAtlasToFile);
         if(type == TEXT_FILE)


### PR DESCRIPTION
## Overview
This PR should fix one of the deadlock issues with our implementation of ORB_SLAM3. We called PreSave() in SaveAtlas() which violates the global lock ordering for the mMutexMapUpdate and mMutexAtlas locks. Tracking::Track has the current map mMutexMapUpdate lock while trying to get mMutexAtlas, while our Save code has mMutexAtlas while trying to get mMutexMapUpdate. I have included the stack trace for the two locked threads during the deadlock in question.

Tracking::Track() thread:
```
#5  std::unique_lock<std::mutex>::unique_lock(std::mutex&) (__m=..., this=0x7ffc9a7c2640)
    at /usr/include/c++/10/bits/unique_lock.h:68
Attempts to lock mMutexAtlas: #6  ORB_SLAM3::Atlas::KeyFramesInMap() (this=0x557b9bf0ea10)
    at /host/slam/slam-libraries/viam-orb-slam3/ORB_SLAM3/src/Atlas.cc:189
#7  0x00007f3c4678f4d4 in ORB_SLAM3::Tracking::NeedNewKeyFrame() (this=0x7f3c34ada010)
    at /host/slam/slam-libraries/viam-orb-slam3/ORB_SLAM3/src/Tracking.cc:3088
#8  ORB_SLAM3::Tracking::NeedNewKeyFrame() (this=0x7f3c34ada010)
    at /host/slam/slam-libraries/viam-orb-slam3/ORB_SLAM3/src/Tracking.cc:3064
Locks mMutexMapUpdate for current map: #9  0x00007f3c4679b2e8 in ORB_SLAM3::Tracking::Track() (this=0x7f3c34ada010)
    at /host/slam/slam-libraries/viam-orb-slam3/ORB_SLAM3/src/Tracking.cc:2244
#10 0x00007f3c4679cc45 in ORB_SLAM3::Tracking::GrabImageRGBD(cv::Mat const&, cv::Mat const&, double const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >)
    (this=this@entry=0x7f3c34ada010, imRGB=..., imD=..., timestamp=@0x7ffc9a80ba08: 5.399399995803833, filename="") at /host/slam/slam-libraries/viam-orb-slam3/ORB_SLAM3/src/Tracking.cc:1560
#11 0x00007f3c4673da73 in ORB_SLAM3::System::TrackRGBD(cv::Mat const&, cv::Mat const&, double const&, std::vector<ORB_SLAM3::IMU::Point, std::allocator<ORB_SLAM3::IMU::Point> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >)
```

System::SaveAtlasAsOsaWithTimestamp() Thread:
```
#4  std::lock_guard<std::mutex>::lock_guard(std::mutex&) (__m=..., this=<synthetic pointer>)
    at /usr/include/c++/10/bits/std_mutex.h:159
Attempts to lock mMutexMapUpdate for all maps: #5  ORB_SLAM3::Atlas::PreSave() (this=0x557b9bf0ea10)
    at /host/slam/slam-libraries/viam-orb-slam3/ORB_SLAM3/src/Atlas.cc:324
Locks mMutexAtlas: #6  0x00007f3c467f191e in ORB_SLAM3::Atlas::SaveAtlas(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >)
    (this=0x557b9bf0ea10, pathSaveFileName="/tmp/2931352026/map/orbslam_int_color_camera_data_2023-02-21T02:48:44.0000Z.osa", strVocabularyName="ORBvoc.txt", strVocabularyChecksum="5420bad0713bc97034dd2a9b2f0cc387") at /host/slam/slam-libraries/viam-orb-slam3/ORB_SLAM3/src/Atlas.cc:360
#7  0x00007f3c4673c9e0 in ORB_SLAM3::System::SaveAtlasAsOsaWithTimestamp(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) (this=0x7f3c10a9fa80,
    this@entry=0x557b9bf30650, pathSaveFileName="/tmp/2931352026/map/orbslam_int_color_camera_data_2023-02-21T02:48:44.0000Z.osa") at /host/slam/slam-libraries/viam-orb-slam3/ORB_SLAM3/src/System.cc:1410
#8  0x0000557b9ac54e5a in viam::SLAMServiceImpl::SaveAtlasAsOsaWithTimestamp(ORB_SLAM3::System*)
    (this=0x7ffc9a80c1d0, SLAM=0x557b9bf30650)
    at /host/slam/slam-libraries/viam-orb-slam3/orbslam_server_v1.cc:724
```

## Notes about my solution:
I had originally tried to lock all of the maps before calling PreSave with something like:
```
    vector<lock_guard<mutex>> map_locks;
    for (Map* pMi : mspMaps) {
        map_locks.push_back(pMi ->mMutexMapUpdate);
    }
    lock_guard<mutex> lock(mMutexAtlas);
    this->PreSave();
```
However this also caused rare deadlocks because the ordering of the maps is not guaranteed to be immutable. 


## Testing:
Pre-patch I had the slam integration tests fail 13/100 runs due to deadlocking.
Post-patch I had the slam integration tests fail 0/100 runs due to deadlocking. 

