### PR TITLE
Pointer Typo in System.cc

### DIFF
--- a/src/System.cc
+++ b/src/System.cc
@@ -1423,8 +1423,8 @@ void System::SaveAtlas(int type){
         //clock_t start = clock();
         {
             // PreSave assumes that the current map is locked
-            Map* currentMap = mpAtlas.GetCurrentMap();
-            std::lock_guard<std::mutex> lock(currentMap -> mMutexMapUpdate ); 
+            Map* currentMap = mpAtlas->GetCurrentMap();
+            std::lock_guard<std::mutex> lock(currentMap->mMutexMapUpdate ); 
             // Save the current session
             mpAtlas->PreSave();
         }


### PR DESCRIPTION
Fixes typo in https://github.com/viamrobotics/ORB_SLAM3/commit/62003209b20bd1eba0159974c63d21f45a3fa702

Related to https://viam.atlassian.net/browse/RSDK-1610